### PR TITLE
Fix variance of expression evaluation benchmarks

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -49,6 +49,7 @@
     "@types/luxon": "^3.2.0",
     "@types/md5": "^2.3.5",
     "@types/xml2js": "^0.4.14",
+    "execa": "^5.1.1",
     "tinybench": "^2.8.0"
   },
   "dependencies": {

--- a/packages/workflow/test/benchTest.ts
+++ b/packages/workflow/test/benchTest.ts
@@ -10,7 +10,9 @@ async function benchTest() {
 	const fixture = baseFixtures[fixtureIndex];
 	const test = fixture.tests[testIndex];
 
-	if ('error' in test || test.type === 'transform') return;
+	if ('error' in test || test.type === 'transform') {
+		throw new Error('Invalid test type');
+	}
 
 	console.log(`Benchmarking: ${fixture.expression} with pid: ${process.pid}`);
 

--- a/packages/workflow/test/benchTest.ts
+++ b/packages/workflow/test/benchTest.ts
@@ -18,7 +18,9 @@ async function benchTest() {
 
 	const bench = withCodSpeed(new Bench());
 	const input = test.input.map((d) => ({ json: d })) as INodeExecutionData[];
-	bench.add(fixture.expression, () => evaluate(fixture.expression, input));
+	bench.add(`fId:${fixtureIndex}-tId:${testIndex}:${fixture.expression}`, () =>
+		evaluate(fixture.expression, input),
+	);
 
 	await bench.run();
 	console.table(bench.table());

--- a/packages/workflow/test/benchTest.ts
+++ b/packages/workflow/test/benchTest.ts
@@ -1,0 +1,25 @@
+import type { INodeExecutionData } from '@/index';
+import { withCodSpeed } from '@codspeed/tinybench-plugin';
+import { Bench } from 'tinybench';
+import { baseFixtures } from './ExpressionFixtures/base';
+import { evaluate } from './evaluate';
+
+async function benchTest() {
+	const fixtureIndex = parseInt(process.argv[2]);
+	const testIndex = parseInt(process.argv[3]);
+	const fixture = baseFixtures[fixtureIndex];
+	const test = fixture.tests[testIndex];
+
+	if ('error' in test || test.type === 'transform') return;
+
+	console.log(`Benchmarking: ${fixture.expression} with pid: ${process.pid}`);
+
+	const bench = withCodSpeed(new Bench());
+	const input = test.input.map((d) => ({ json: d })) as INodeExecutionData[];
+	bench.add(fixture.expression, () => evaluate(fixture.expression, input));
+
+	await bench.run();
+	console.table(bench.table());
+}
+
+void benchTest();

--- a/packages/workflow/test/benchmark.ts
+++ b/packages/workflow/test/benchmark.ts
@@ -3,7 +3,9 @@ import { baseFixtures } from './ExpressionFixtures/base';
 
 async function main() {
 	for (const [fixtureIndex, fixture] of baseFixtures.entries()) {
-		for (const [testIndex, _] of fixture.tests.entries()) {
+		for (const [testIndex, test] of fixture.tests.entries()) {
+			if ('error' in test || test.type === 'transform') continue;
+
 			const bench = await execa.node('dist/test/benchTest.js', [
 				fixtureIndex.toString(),
 				testIndex.toString(),

--- a/packages/workflow/test/benchmark.ts
+++ b/packages/workflow/test/benchmark.ts
@@ -1,31 +1,16 @@
-import { Bench } from 'tinybench';
-import { withCodSpeed } from '@codspeed/tinybench-plugin';
+import execa from 'execa';
 import { baseFixtures } from './ExpressionFixtures/base';
-import { evaluate } from './evaluate';
-import type { INodeExecutionData } from '@/index';
-
-function addExpressionEvaluationTasks(bench: Bench) {
-	for (const fixture of baseFixtures) {
-		for (const test of fixture.tests) {
-			if ('error' in test) continue;
-
-			if (test.type === 'evaluation') {
-				const input = test.input.map((d) => ({ json: d })) as INodeExecutionData[];
-				bench.add(fixture.expression, () => evaluate(fixture.expression, input));
-			}
-		}
-	}
-}
 
 async function main() {
-	const bench = withCodSpeed(new Bench());
-
-	addExpressionEvaluationTasks(bench);
-
-	await bench.warmup();
-	await bench.run();
-
-	console.table(bench.table());
+	for (const [fixtureIndex, fixture] of baseFixtures.entries()) {
+		for (const [testIndex, _] of fixture.tests.entries()) {
+			const bench = await execa.node('dist/test/benchTest.js', [
+				fixtureIndex.toString(),
+				testIndex.toString(),
+			]);
+			console.log(bench.stdout);
+		}
+	}
 }
 
 void main();

--- a/packages/workflow/test/benchmark.ts
+++ b/packages/workflow/test/benchmark.ts
@@ -2,17 +2,25 @@ import execa from 'execa';
 import { baseFixtures } from './ExpressionFixtures/base';
 
 async function main() {
+	const promises: Array<Promise<void>> = [];
+
 	for (const [fixtureIndex, fixture] of baseFixtures.entries()) {
 		for (const [testIndex, test] of fixture.tests.entries()) {
 			if ('error' in test || test.type === 'transform') continue;
 
-			const bench = await execa.node('dist/test/benchTest.js', [
-				fixtureIndex.toString(),
-				testIndex.toString(),
-			]);
-			console.log(bench.stdout);
+			promises.push(
+				(async () => {
+					const bench = await execa.node('dist/test/benchTest.js', [
+						fixtureIndex.toString(),
+						testIndex.toString(),
+					]);
+					console.log(bench.stdout);
+				})(),
+			);
 		}
 	}
+
+	await Promise.all(promises);
 }
 
 void main();

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,7 +1,16 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..dd7b9de44fc8b9c60dab1d0114abf6f5c00017a7 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..591452e618bb297d21dcf066cff7606ea2460408 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
+@@ -67,7 +67,7 @@ function isCodSpeedBenchOptions(options) {
+   return "uri" in options;
+ }
+ function withCodSpeed(bench) {
+-  if (!core.Measurement.isInstrumented()) {
++  if (false) {
+     const rawRun = bench.run;
+     bench.run = async () => {
+       console.warn(
 @@ -89,13 +89,17 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      core.setupCore();
@@ -16,16 +25,25 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..dd7b9de44fc8b9c60dab1d0114abf6f5
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 10; i++) {
++      for (let i = 0; i < 100; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);
        await core.mongoMeasurement.start(uri);
        await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..bd45a843739c898b74cff2aec1d0e37023e0554b 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..078ab22a6772f3988a0789966b5b84e2ed7e15a7 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
+@@ -65,7 +65,7 @@ function isCodSpeedBenchOptions(options) {
+   return "uri" in options;
+ }
+ function withCodSpeed(bench) {
+-  if (!Measurement.isInstrumented()) {
++  if (false) {
+     const rawRun = bench.run;
+     bench.run = async () => {
+       console.warn(
 @@ -87,13 +87,17 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      setupCore();
@@ -40,7 +58,7 @@ index e20505951341fbfe7a9142c222aff1221ab19530..bd45a843739c898b74cff2aec1d0e370
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 10; i++) {
++      for (let i = 0; i < 100; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..5f17a0ba1c348fd9fa36830ac217b3a271fd901d 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..f08d01adcd1d5fa865fcac797aa145c1fa5e96c8 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
 @@ -67,7 +67,7 @@ function isCodSpeedBenchOptions(options) {
@@ -25,14 +25,14 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..5f17a0ba1c348fd9fa36830ac217b3a2
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 1000; i++) {
++      for (let i = 0; i < 10; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);
        await core.mongoMeasurement.start(uri);
        await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..626ee3ea69f4b6a8cb6173ad2d72c6cae4063b1a 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..32af677af135352a6d7126cdcb40ef9ed8281570 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
 @@ -65,7 +65,7 @@ function isCodSpeedBenchOptions(options) {
@@ -58,7 +58,7 @@ index e20505951341fbfe7a9142c222aff1221ab19530..626ee3ea69f4b6a8cb6173ad2d72c6ca
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 1000; i++) {
++      for (let i = 0; i < 10; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,17 +1,8 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..b1c76c7ce4ba0a185687df7525b0856cd7387e66 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..78359d9cc0bcf3a3de7a11278407d2485fb563a4 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
-@@ -67,7 +67,7 @@ function isCodSpeedBenchOptions(options) {
-   return "uri" in options;
- }
- function withCodSpeed(bench) {
--  if (!core.Measurement.isInstrumented()) {
-+  if (false) {
-     const rawRun = bench.run;
-     bench.run = async () => {
-       console.warn(
-@@ -89,13 +89,17 @@ function withCodSpeed(bench) {
+@@ -89,7 +89,8 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      core.setupCore();
      for (const task of bench.tasks) {
@@ -19,32 +10,13 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..b1c76c7ce4ba0a185687df7525b0856c
 +      let uri = isCodSpeedBenchOptions(task.opts) ? task.opts.uri : `${rootCallingFile}::${task.name}`;
 +      uri = uri.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
        await task.opts.beforeAll?.call(task);
--      await core.optimizeFunction(async () => {
-+      const optimize = async () => await core.optimizeFunction(async () => {
+       await core.optimizeFunction(async () => {
          await task.opts.beforeEach?.call(task);
-         await task.fn();
-         await task.opts.afterEach?.call(task);
-       });
-+      for (let i = 0; i < 1; i++) {
-+        await optimize();
-+      }
-       await task.opts.beforeEach?.call(task);
-       await core.mongoMeasurement.start(uri);
-       await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..9d40ec36c24ca9ef346195cce2dc0cf96c7ed7b7 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..728f832fc3e69c931ecc59c966f03d2946f2b84c 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
-@@ -65,7 +65,7 @@ function isCodSpeedBenchOptions(options) {
-   return "uri" in options;
- }
- function withCodSpeed(bench) {
--  if (!Measurement.isInstrumented()) {
-+  if (false) {
-     const rawRun = bench.run;
-     bench.run = async () => {
-       console.warn(
-@@ -87,13 +87,17 @@ function withCodSpeed(bench) {
+@@ -87,7 +87,8 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      setupCore();
      for (const task of bench.tasks) {
@@ -52,15 +24,5 @@ index e20505951341fbfe7a9142c222aff1221ab19530..9d40ec36c24ca9ef346195cce2dc0cf9
 +      let uri = isCodSpeedBenchOptions(task.opts) ? task.opts.uri : `${rootCallingFile}::${task.name}`;
 +      uri = uri.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
        await task.opts.beforeAll?.call(task);
--      await optimizeFunction(async () => {
-+      const optimize = async () => await core.optimizeFunction(async () => {
+       await optimizeFunction(async () => {
          await task.opts.beforeEach?.call(task);
-         await task.fn();
-         await task.opts.afterEach?.call(task);
-       });
-+      for (let i = 0; i < 1; i++) {
-+        await optimize();
-+      }
-       await task.opts.beforeEach?.call(task);
-       await mongoMeasurement.start(uri);
-       await async function __codspeed_root_frame__() {

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..f08d01adcd1d5fa865fcac797aa145c1fa5e96c8 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..b1c76c7ce4ba0a185687df7525b0856cd7387e66 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
 @@ -67,7 +67,7 @@ function isCodSpeedBenchOptions(options) {
@@ -25,14 +25,14 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..f08d01adcd1d5fa865fcac797aa145c1
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 10; i++) {
++      for (let i = 0; i < 1; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);
        await core.mongoMeasurement.start(uri);
        await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..32af677af135352a6d7126cdcb40ef9ed8281570 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..9d40ec36c24ca9ef346195cce2dc0cf96c7ed7b7 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
 @@ -65,7 +65,7 @@ function isCodSpeedBenchOptions(options) {
@@ -58,7 +58,7 @@ index e20505951341fbfe7a9142c222aff1221ab19530..32af677af135352a6d7126cdcb40ef9e
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 10; i++) {
++      for (let i = 0; i < 1; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..591452e618bb297d21dcf066cff7606ea2460408 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..5f17a0ba1c348fd9fa36830ac217b3a271fd901d 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
 @@ -67,7 +67,7 @@ function isCodSpeedBenchOptions(options) {
@@ -25,14 +25,14 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..591452e618bb297d21dcf066cff7606e
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 100; i++) {
++      for (let i = 0; i < 1000; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);
        await core.mongoMeasurement.start(uri);
        await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..078ab22a6772f3988a0789966b5b84e2ed7e15a7 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..626ee3ea69f4b6a8cb6173ad2d72c6cae4063b1a 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
 @@ -65,7 +65,7 @@ function isCodSpeedBenchOptions(options) {
@@ -58,7 +58,7 @@ index e20505951341fbfe7a9142c222aff1221ab19530..078ab22a6772f3988a0789966b5b84e2
          await task.fn();
          await task.opts.afterEach?.call(task);
        });
-+      for (let i = 0; i < 100; i++) {
++      for (let i = 0; i < 1000; i++) {
 +        await optimize();
 +      }
        await task.opts.beforeEach?.call(task);

--- a/patches/@codspeed__tinybench-plugin@3.1.0.patch
+++ b/patches/@codspeed__tinybench-plugin@3.1.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/index.cjs.js b/dist/index.cjs.js
-index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..78359d9cc0bcf3a3de7a11278407d2485fb563a4 100644
+index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..dd7b9de44fc8b9c60dab1d0114abf6f5c00017a7 100644
 --- a/dist/index.cjs.js
 +++ b/dist/index.cjs.js
-@@ -89,7 +89,8 @@ function withCodSpeed(bench) {
+@@ -89,13 +89,17 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      core.setupCore();
      for (const task of bench.tasks) {
@@ -10,13 +10,23 @@ index a75964e40eaeff15df33fabd3c0bef20e9b1e5dd..78359d9cc0bcf3a3de7a11278407d248
 +      let uri = isCodSpeedBenchOptions(task.opts) ? task.opts.uri : `${rootCallingFile}::${task.name}`;
 +      uri = uri.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
        await task.opts.beforeAll?.call(task);
-       await core.optimizeFunction(async () => {
+-      await core.optimizeFunction(async () => {
++      const optimize = async () => await core.optimizeFunction(async () => {
          await task.opts.beforeEach?.call(task);
+         await task.fn();
+         await task.opts.afterEach?.call(task);
+       });
++      for (let i = 0; i < 10; i++) {
++        await optimize();
++      }
+       await task.opts.beforeEach?.call(task);
+       await core.mongoMeasurement.start(uri);
+       await async function __codspeed_root_frame__() {
 diff --git a/dist/index.es5.js b/dist/index.es5.js
-index e20505951341fbfe7a9142c222aff1221ab19530..728f832fc3e69c931ecc59c966f03d2946f2b84c 100644
+index e20505951341fbfe7a9142c222aff1221ab19530..bd45a843739c898b74cff2aec1d0e37023e0554b 100644
 --- a/dist/index.es5.js
 +++ b/dist/index.es5.js
-@@ -87,7 +87,8 @@ function withCodSpeed(bench) {
+@@ -87,13 +87,17 @@ function withCodSpeed(bench) {
      console.log(`[CodSpeed] running with @codspeed/tinybench v${"3.1.0"}`);
      setupCore();
      for (const task of bench.tasks) {
@@ -24,5 +34,15 @@ index e20505951341fbfe7a9142c222aff1221ab19530..728f832fc3e69c931ecc59c966f03d29
 +      let uri = isCodSpeedBenchOptions(task.opts) ? task.opts.uri : `${rootCallingFile}::${task.name}`;
 +      uri = uri.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
        await task.opts.beforeAll?.call(task);
-       await optimizeFunction(async () => {
+-      await optimizeFunction(async () => {
++      const optimize = async () => await core.optimizeFunction(async () => {
          await task.opts.beforeEach?.call(task);
+         await task.fn();
+         await task.opts.afterEach?.call(task);
+       });
++      for (let i = 0; i < 10; i++) {
++        await optimize();
++      }
+       await task.opts.beforeEach?.call(task);
+       await mongoMeasurement.start(uri);
+       await async function __codspeed_root_frame__() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: ywpin23vvqeq3ll2jtaph4267i
+    hash: dqrs72ysnfk7w7ybqww2i7r4ae
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=ywpin23vvqeq3ll2jtaph4267i)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=dqrs72ysnfk7w7ybqww2i7r4ae)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4760,7 +4760,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=ywpin23vvqeq3ll2jtaph4267i)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=dqrs72ysnfk7w7ybqww2i7r4ae)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: 5ct25wqstmk22aen7svm6gt4mq
+    hash: ywpin23vvqeq3ll2jtaph4267i
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=5ct25wqstmk22aen7svm6gt4mq)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=ywpin23vvqeq3ll2jtaph4267i)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4763,7 +4763,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=5ct25wqstmk22aen7svm6gt4mq)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=ywpin23vvqeq3ll2jtaph4267i)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: rk3a2z6fcsrht3nmceajv72ihy
+    hash: 5ct25wqstmk22aen7svm6gt4mq
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=rk3a2z6fcsrht3nmceajv72ihy)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=5ct25wqstmk22aen7svm6gt4mq)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4763,7 +4763,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=rk3a2z6fcsrht3nmceajv72ihy)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=5ct25wqstmk22aen7svm6gt4mq)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: oowtazp4qowlzfwqmn4mwak5ii
+    hash: kdlnlfnytjmx35h6w6m35vaepa
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=oowtazp4qowlzfwqmn4mwak5ii)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=kdlnlfnytjmx35h6w6m35vaepa)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4760,7 +4760,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=oowtazp4qowlzfwqmn4mwak5ii)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=kdlnlfnytjmx35h6w6m35vaepa)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: kdlnlfnytjmx35h6w6m35vaepa
+    hash: rk3a2z6fcsrht3nmceajv72ihy
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=kdlnlfnytjmx35h6w6m35vaepa)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=rk3a2z6fcsrht3nmceajv72ihy)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4763,7 +4763,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=kdlnlfnytjmx35h6w6m35vaepa)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=rk3a2z6fcsrht3nmceajv72ihy)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
 
 patchedDependencies:
   '@codspeed/tinybench-plugin@3.1.0':
-    hash: dqrs72ysnfk7w7ybqww2i7r4ae
+    hash: oowtazp4qowlzfwqmn4mwak5ii
     path: patches/@codspeed__tinybench-plugin@3.1.0.patch
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
@@ -1657,7 +1657,7 @@ importers:
     devDependencies:
       '@codspeed/tinybench-plugin':
         specifier: ^3.1.0
-        version: 3.1.0(patch_hash=dqrs72ysnfk7w7ybqww2i7r4ae)(tinybench@2.8.0)
+        version: 3.1.0(patch_hash=oowtazp4qowlzfwqmn4mwak5ii)(tinybench@2.8.0)
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -4760,7 +4760,7 @@ packages:
       - debug
     dev: true
 
-  /@codspeed/tinybench-plugin@3.1.0(patch_hash=dqrs72ysnfk7w7ybqww2i7r4ae)(tinybench@2.8.0):
+  /@codspeed/tinybench-plugin@3.1.0(patch_hash=oowtazp4qowlzfwqmn4mwak5ii)(tinybench@2.8.0):
     resolution: {integrity: sha512-yl0WzzUGIXkZzWaw7+2U+xGkuIal1Rs9hS09DtlDZGGAcGRoMMU5d2vyCS8nBrna4hrPQZ5Sx/hIKerO+lqWaw==}
     peerDependencies:
       tinybench: ^2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1679,6 +1679,9 @@ importers:
       '@types/xml2js':
         specifier: ^0.4.14
         version: 0.4.14
+      execa:
+        specifier: ^5.1.1
+        version: 5.1.1
       tinybench:
         specifier: ^2.8.0
         version: 2.8.0
@@ -14536,7 +14539,7 @@ packages:
       human-signals: 5.0.0
       is-stream: 3.0.0
       merge-stream: 2.0.0
-      npm-run-path: 5.1.0
+      npm-run-path: 5.3.0
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
@@ -19436,8 +19439,8 @@ packages:
     dependencies:
       path-key: 3.1.1
 
-  /npm-run-path@5.1.0:
-    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0


### PR DESCRIPTION
## Variance check

The benchmarks are stable:

```text
Found 39 runs for adriencaccia/n8n (14730eefa21f31ea39ec420b58df6f7870300593)
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────┬───────────────────┬─────────────────────┬──────────┬──────────────────┐
│                                                                                                                                        (index)                                                                                                                                         │ average  │ standardDeviation │ varianceCoefficient │  range   │ rangeCoefficient │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────────────┼─────────────────────┼──────────┼──────────────────┤
│                                                                                                      packages/workflow/dist/test/benchTest.js::fId:29-tId:0:={{Math.min(1, 2);}}                                                                                                       │ '1.2 ms' │    '770.8 ns'     │       '0.1%'        │ '3.3 µs' │      '0.3%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:31-tId:3:={{ !!$json["different"]["name"] || !!$json["different"]["phone"] }}                                                                               │ '1.6 ms' │    '827.3 ns'     │       '0.1%'        │  '4 µs'  │      '0.2%'      │
│                                                                                             packages/workflow/dist/test/benchTest.js::fId:34-tId:0:={{/^\d+$/.test($json["search_term"])}}                                                                                             │ '1.6 ms' │    '836.8 ns'     │       '0.1%'        │ '4.1 µs' │      '0.2%'      │
│                                                                                     packages/workflow/dist/test/benchTest.js::fId:18-tId:0:={{ [].concat($json["Create or update"].json["vid"]) }}                                                                                     │ '1.6 ms' │     '810 ns'      │       '0.0%'        │ '3.3 µs' │      '0.2%'      │
│                                                                                                       packages/workflow/dist/test/benchTest.js::fId:1-tId:3:={{ $json["test"] }}                                                                                                       │ '1.6 ms' │    '785.7 ns'     │       '0.0%'        │ '4.1 µs' │      '0.3%'      │
│                                                                                          packages/workflow/dist/test/benchTest.js::fId:14-tId:0:={{$json["图片数量判断"].data["imgList"][0]}}                                                                                          │ '1.6 ms' │    '744.7 ns'     │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                                                                    packages/workflow/dist/test/benchTest.js::fId:15-tId:0:={{ $json["phone"] ?? 0}}                                                                                                    │ '1.6 ms' │     '746 ns'      │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                                                             packages/workflow/dist/test/benchTest.js::fId:3-tId:0:={{$json[$json["Set2"].json["apiKey"]]}}                                                                                             │ '1.6 ms' │    '746.5 ns'     │       '0.0%'        │ '4.5 µs' │      '0.3%'      │
│                                                                                                  packages/workflow/dist/test/benchTest.js::fId:30-tId:0:={{new String().toString();}}                                                                                                  │ '1.6 ms' │    '731.8 ns'     │       '0.0%'        │ '4.3 µs' │      '0.3%'      │
│                                                                            packages/workflow/dist/test/benchTest.js::fId:19-tId:0:=https://example.com/test?id={{$json["Crypto"].json["data"].substr(0,6)}}                                                                            │ '1.6 ms' │     '740 ns'      │       '0.0%'        │ '3.8 µs' │      '0.2%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:1:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '729.3 ns'     │       '0.0%'        │ '4.3 µs' │      '0.3%'      │
│                                                                                                     packages/workflow/dist/test/benchTest.js::fId:12-tId:0:={{ $json.toString() }}                                                                                                     │ '1.6 ms' │    '724.9 ns'     │       '0.0%'        │ '3.3 µs' │      '0.2%'      │
│                                                           packages/workflow/dist/test/benchTest.js::fId:22-tId:0:={{ $json["projectName"] == "" ? "Project Group " + ($json["projectsCount"] + 1) : $json["projectName"] }}                                                            │ '1.6 ms' │     '731 ns'      │       '0.0%'        │ '2.9 µs' │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:37-tId:2:={{ $json["data"]["errors"] && $json["data"]["errors"].length > 0 }}                                                                               │ '1.6 ms' │    '710.2 ns'     │       '0.0%'        │ '2.6 µs' │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:31-tId:2:={{ !!$json["different"]["name"] || !!$json["different"]["phone"] }}                                                                               │ '1.6 ms' │    '713.1 ns'     │       '0.0%'        │ '3.1 µs' │      '0.2%'      │
│                                                                                                 packages/workflow/dist/test/benchTest.js::fId:46-tId:0:={{ String("testing").length }}                                                                                                 │ '1.6 ms' │    '696.1 ns'     │       '0.0%'        │ '3.2 µs' │      '0.2%'      │
│                                                                                                          packages/workflow/dist/test/benchTest.js::fId:8-tId:0:={{$runIndex}}                                                                                                          │ '1.6 ms' │    '692.8 ns'     │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                        packages/workflow/dist/test/benchTest.js::fId:21-tId:0:={{(new Date($json["end"]["date"]).getTime() - new Date($json["start"]["date"]).getTime()) / (1000 * 3600 * 24)}}                                                        │ '1.6 ms' │    '706.4 ns'     │       '0.0%'        │ '3.8 µs' │      '0.2%'      │
│                                                                                             packages/workflow/dist/test/benchTest.js::fId:34-tId:1:={{/^\d+$/.test($json["search_term"])}}                                                                                             │ '1.6 ms' │    '698.5 ns'     │       '0.0%'        │ '3.4 µs' │      '0.2%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:28-tId:1:={{$json["HTTP Request"].json["paging"] ? true : false}}                                                                                     │ '1.6 ms' │    '688.2 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                                                                  packages/workflow/dist/test/benchTest.js::fId:20-tId:0:={{ $json["body"]["project"]["name"].match(/\[(\d+)]/)[1] }}                                                                                   │ '1.7 ms' │    '701.2 ns'     │       '0.0%'        │ '3.1 µs' │      '0.2%'      │
│                                                                                             packages/workflow/dist/test/benchTest.js::fId:13-tId:0:={{Math.floor(Math.min(1, 2) * 100);}}                                                                                              │ '1.4 ms' │    '594.9 ns'     │       '0.0%'        │ '2.2 µs' │      '0.2%'      │
│                                                           packages/workflow/dist/test/benchTest.js::fId:25-tId:0:={{ (parseFloat($json["Bid"].replace(',', '.')) * parseFloat($json["Baserow"].json["Count"])).toFixed(2) }}                                                           │ '1.6 ms' │    '680.2 ns'     │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                                  packages/workflow/dist/test/benchTest.js::fId:9-tId:0:={{ new String().toString() }}                                                                                                  │ '1.6 ms' │    '657.7 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                                                                                       packages/workflow/dist/test/benchTest.js::fId:1-tId:0:={{ $json["test"] }}                                                                                                       │ '1.6 ms' │    '660.8 ns'     │       '0.0%'        │ '3.2 µs' │      '0.2%'      │
│                                                                                                packages/workflow/dist/test/benchTest.js::fId:0-tId:1:={{$json["contact"]["FirstName"]}}                                                                                                │ '1.7 ms' │    '693.7 ns'     │       '0.0%'        │ '3.1 µs' │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:31-tId:1:={{ !!$json["different"]["name"] || !!$json["different"]["phone"] }}                                                                               │ '1.6 ms' │    '665.1 ns'     │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                                                                            packages/workflow/dist/test/benchTest.js::fId:32-tId:0:={{200}}                                                                                                             │ '1.6 ms' │    '647.9 ns'     │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                                                                 packages/workflow/dist/test/benchTest.js::fId:39-tId:0:={{!!$json["data"]["errors"]}}                                                                                                  │ '1.6 ms' │    '651.5 ns'     │       '0.0%'        │  '3 µs'  │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:31-tId:0:={{ !!$json["different"]["name"] || !!$json["different"]["phone"] }}                                                                               │ '1.6 ms' │    '644.4 ns'     │       '0.0%'        │ '3.5 µs' │      '0.2%'      │
│                                               packages/workflow/dist/test/benchTest.js::fId:27-tId:1:={{$json["Find by ID"].json["id"] != "" && $json["Find by ID"].json["id"] != null && $json["Find by ID"].json["id"] != undefined}}                                                │ '1.6 ms' │    '647.4 ns'     │       '0.0%'        │ '2.5 µs' │      '0.2%'      │
│                                                                                                    packages/workflow/dist/test/benchTest.js::fId:15-tId:2:={{ $json["phone"] ?? 0}}                                                                                                    │ '1.6 ms' │    '639.3 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                                                                            packages/workflow/dist/test/benchTest.js::fId:6-tId:0:= {{$json["dig check CF"].data["stdout"]}}                                                                                            │ '1.6 ms' │    '640.7 ns'     │       '0.0%'        │ '2.7 µs' │      '0.2%'      │
│                                                                         packages/workflow/dist/test/benchTest.js::fId:17-tId:0:={{$json['Webhook1'].json["headers"]["x-api-key"] +'-'+ parseInt($json.test)}}                                                                          │ '1.6 ms' │    '627.8 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                                                                                       packages/workflow/dist/test/benchTest.js::fId:1-tId:2:={{ $json["test"] }}                                                                                                       │ '1.6 ms' │    '614.3 ns'     │       '0.0%'        │ '2.5 µs' │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:37-tId:0:={{ $json["data"]["errors"] && $json["data"]["errors"].length > 0 }}                                                                               │ '1.6 ms' │    '620.1 ns'     │       '0.0%'        │ '2.9 µs' │      '0.2%'      │
│                                                                                     packages/workflow/dist/test/benchTest.js::fId:43-tId:1:={{typeof $json["person"].json["name"] != "undefined"}}                                                                                     │ '1.6 ms' │    '614.4 ns'     │       '0.0%'        │ '2.4 µs' │      '0.1%'      │
│                                                           packages/workflow/dist/test/benchTest.js::fId:22-tId:1:={{ $json["projectName"] == "" ? "Project Group " + ($json["projectsCount"] + 1) : $json["projectName"] }}                                                            │ '1.6 ms' │    '615.2 ns'     │       '0.0%'        │ '2.7 µs' │      '0.2%'      │
│                                                                                                packages/workflow/dist/test/benchTest.js::fId:35-tId:0:={{ `test\nvalue\nmulti\nline` }}                                                                                                │ '1.6 ms' │    '593.6 ns'     │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                         packages/workflow/dist/test/benchTest.js::fId:45-tId:1:={{ 'domain' in $json && $json.domain != null}}                                                                                         │ '1.6 ms' │    '605.2 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                                                                      packages/workflow/dist/test/benchTest.js::fId:24-tId:0:={{$json["Find by ID1"].json["fields"]["clicks"]+1}}                                                                                       │ '1.6 ms' │    '598.1 ns'     │       '0.0%'        │ '2.4 µs' │      '0.2%'      │
│                                                                                     packages/workflow/dist/test/benchTest.js::fId:43-tId:0:={{typeof $json["person"].json["name"] != "undefined"}}                                                                                     │ '1.6 ms' │    '596.7 ns'     │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                                    packages/workflow/dist/test/benchTest.js::fId:15-tId:1:={{ $json["phone"] ?? 0}}                                                                                                    │ '1.6 ms' │    '593.5 ns'     │       '0.0%'        │ '3.2 µs' │      '0.2%'      │
│                                                                             packages/workflow/dist/test/benchTest.js::fId:42-tId:0:={{ [{'name': 'something', 'batch_size':1000, 'ignore_cols':['x']}] }}                                                                              │ '1.6 ms' │    '584.2 ns'     │       '0.0%'        │ '2.7 µs' │      '0.2%'      │
│                                                                     packages/workflow/dist/test/benchTest.js::fId:16-tId:0:={{$json['Webhook1'].json["headers"]["x-api-key"] +'-'+ new String('test').toString()}}                                                                     │ '1.6 ms' │    '589.5 ns'     │       '0.0%'        │ '2.6 µs' │      '0.2%'      │
│                                                                              packages/workflow/dist/test/benchTest.js::fId:37-tId:1:={{ $json["data"]["errors"] && $json["data"]["errors"].length > 0 }}                                                                               │ '1.6 ms' │    '590.2 ns'     │       '0.0%'        │ '2.5 µs' │      '0.2%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:4:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │     '582 ns'      │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:0:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '581.9 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                                           packages/workflow/dist/test/benchTest.js::fId:38-tId:0:={{asdas}}                                                                                                            │ '1.6 ms' │    '573.2 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:28-tId:0:={{$json["HTTP Request"].json["paging"] ? true : false}}                                                                                     │ '1.6 ms' │    '579.5 ns'     │       '0.0%'        │ '2.9 µs' │      '0.2%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:2:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '576.8 ns'     │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                                packages/workflow/dist/test/benchTest.js::fId:0-tId:0:={{$json["contact"]["FirstName"]}}                                                                                                │ '1.6 ms' │    '569.6 ns'     │       '0.0%'        │ '2.6 µs' │      '0.2%'      │
│                                                                                         packages/workflow/dist/test/benchTest.js::fId:45-tId:0:={{ 'domain' in $json && $json.domain != null}}                                                                                         │ '1.6 ms' │    '570.5 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:3:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '557.8 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                              packages/workflow/dist/test/benchTest.js::fId:36-tId:0:={{ { "data": $json.body.choices } }}                                                                                              │ '1.6 ms' │     '555 ns'      │       '0.0%'        │ '2.5 µs' │      '0.2%'      │
│                                                                                        packages/workflow/dist/test/benchTest.js::fId:44-tId:1:={{ $json?.data == undefined ? '' : $json.data }}                                                                                        │ '1.6 ms' │    '554.7 ns'     │       '0.0%'        │ '2.4 µs' │      '0.1%'      │
│                                                                                         packages/workflow/dist/test/benchTest.js::fId:2-tId:0:={{$json["test"].json["message"]["message_id"]}}                                                                                         │ '1.6 ms' │    '549.1 ns'     │       '0.0%'        │ '2.4 µs' │      '0.1%'      │
│                                                packages/workflow/dist/test/benchTest.js::fId:5-tId:0:=https://example.com/api/v1/workspaces/{{$json["Clockify1"].parameter["workspaceId"]}}/projects/{{$json["Clockify1"].json["id"]}}                                                 │ '1.1 ms' │    '390.2 ns'     │       '0.0%'        │ '1.4 µs' │      '0.1%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:6:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '544.5 ns'     │       '0.0%'        │ '2.8 µs' │      '0.2%'      │
│                                               packages/workflow/dist/test/benchTest.js::fId:27-tId:3:={{$json["Find by ID"].json["id"] != "" && $json["Find by ID"].json["id"] != null && $json["Find by ID"].json["id"] != undefined}}                                                │ '1.6 ms' │    '544.5 ns'     │       '0.0%'        │ '2.7 µs' │      '0.2%'      │
│                                                                                            packages/workflow/dist/test/benchTest.js::fId:33-tId:0:={{$json.assetValue * $json.value / 100}}                                                                                            │ '1.6 ms' │    '539.3 ns'     │       '0.0%'        │ '2.3 µs' │      '0.1%'      │
│                                                                                                              packages/workflow/dist/test/benchTest.js::fId:40-tId:0:=TRUE                                                                                                              │ '1.1 ms' │    '361.9 ns'     │       '0.0%'        │ '1.8 µs' │      '0.2%'      │
│                                                                                                       packages/workflow/dist/test/benchTest.js::fId:1-tId:1:={{ $json["test"] }}                                                                                                       │ '1.6 ms' │    '512.6 ns'     │       '0.0%'        │  '2 µs'  │      '0.1%'      │
│                                                                                                           packages/workflow/dist/test/benchTest.js::fId:38-tId:1:={{asdas}}                                                                                                            │ '1.6 ms' │    '501.2 ns'     │       '0.0%'        │ '2.5 µs' │      '0.2%'      │
│                                                                                    packages/workflow/dist/test/benchTest.js::fId:41-tId:5:={{ !$json?.data?.data?.issues?.pageInfo?.hasNextPage }}                                                                                     │ '1.6 ms' │    '502.8 ns'     │       '0.0%'        │  '2 µs'  │      '0.1%'      │
│                                                                                         packages/workflow/dist/test/benchTest.js::fId:11-tId:0:={{$json["GetTicket"].json["tickets"].length}}                                                                                          │ '1.6 ms' │     '502 ns'      │       '0.0%'        │ '1.9 µs' │      '0.1%'      │
│                                               packages/workflow/dist/test/benchTest.js::fId:27-tId:0:={{$json["Find by ID"].json["id"] != "" && $json["Find by ID"].json["id"] != null && $json["Find by ID"].json["id"] != undefined}}                                                │ '1.7 ms' │    '510.1 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                        packages/workflow/dist/test/benchTest.js::fId:23-tId:0:={{new Date($json["created_at"]).toISOString()}}                                                                                         │ '1.6 ms' │     '495 ns'      │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                         packages/workflow/dist/test/benchTest.js::fId:45-tId:2:={{ 'domain' in $json && $json.domain != null}}                                                                                         │ '1.6 ms' │    '488.6 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│ packages/workflow/dist/test/benchTest.js::fId:26-tId:0:={\n\t"article": {\n\t\t"title": "{{$json["body"]["entry"]["Title"]}}",\n\t\t"published": true,\n\t\t"article_markdown": "{{$json["body"]["entry"]["PostContent"]}}",\n\t\t"tags":["{{$json["body"]["entry"]["Tag"]}}"]\n\t}\n} │ '1.2 ms' │    '349.9 ns'     │       '0.0%'        │ '1.8 µs' │      '0.2%'      │
│                                                                                                 packages/workflow/dist/test/benchTest.js::fId:39-tId:1:={{!!$json["data"]["errors"]}}                                                                                                  │ '1.6 ms' │    '472.2 ns'     │       '0.0%'        │ '2.2 µs' │      '0.1%'      │
│                                          packages/workflow/dist/test/benchTest.js::fId:10-tId:0:={{(Date.parse($json["IF Zoom meeting"].json["end"]["dateTime"])-Date.parse($json["IF Zoom meeting"].json["start"]["dateTime"]))/(60*1000)}}                                           │ '1.6 ms' │    '473.1 ns'     │       '0.0%'        │ '1.9 µs' │      '0.1%'      │
│                                               packages/workflow/dist/test/benchTest.js::fId:27-tId:2:={{$json["Find by ID"].json["id"] != "" && $json["Find by ID"].json["id"] != null && $json["Find by ID"].json["id"] != undefined}}                                                │ '1.6 ms' │    '471.2 ns'     │       '0.0%'        │ '2.1 µs' │      '0.1%'      │
│                                                                                          packages/workflow/dist/test/benchTest.js::fId:4-tId:0:={{$json["get"].json["recipes"][0]["image"]}}                                                                                           │ '1.6 ms' │    '438.1 ns'     │       '0.0%'        │ '1.7 µs' │      '0.1%'      │
│                                                                                        packages/workflow/dist/test/benchTest.js::fId:44-tId:0:={{ $json?.data == undefined ? '' : $json.data }}                                                                                        │ '1.6 ms' │    '422.1 ns'     │       '0.0%'        │  '2 µs'  │      '0.1%'      │
│                                                                               packages/workflow/dist/test/benchTest.js::fId:7-tId:0:={{$item(0).$json["Set URL"].json["base_domain"]}}{{$json["link"]}}                                                                                │ '1.8 ms' │    '385.8 ns'     │       '0.0%'        │ '1.9 µs' │      '0.1%'      │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────┴───────────────────┴─────────────────────┴──────────┴──────────────────┘
```